### PR TITLE
Added missing prereq namespace::clean as suggested by CPANTS.

### DIFF
--- a/meta/makefile.pret
+++ b/meta/makefile.pret
@@ -14,6 +14,7 @@
 	:runtime-suggestion     [ :on "RDF::Endpoint"^^:CpanId ];
 	:runtime-suggestion     [ :on "Test::LWP::UserAgent 0.027"^^:CpanId ];
         :runtime-requirement    [ :on "Moo 1.006000"^^:CpanId ];
+        :runtime-requirement    [ :on "namespace::clean"^^:CpanId ];
         :runtime-requirement    [ :on "Attean 0.010"^^:CpanId ];
         :runtime-requirement    [ :on "Types::Standard"^^:CpanId ];
         :runtime-requirement    [ :on "Types::URI"^^:CpanId ];


### PR DESCRIPTION
Hi @kjetilk 

Please review the PR.
https://cpants.cpanauthors.org/release/KJETILK/AtteanX-Store-SPARQL-0.012

Many Thanks.
Best Regards,
Mohammad S Anwar